### PR TITLE
fix: 'api-consumer' compilation

### DIFF
--- a/api-consumer/BUILD
+++ b/api-consumer/BUILD
@@ -13,5 +13,5 @@ gerrit_plugin(
 java_library(
     name = "api-provider-neverlink",
     neverlink = 1,
-    exports = ["//plugins/api-provider:api-provider.api"],
+    exports = ["//plugins/api-provider"],
 )


### PR DESCRIPTION
At present it throws the following error:
```
  ERROR: gerrit/plugins/api-consumer/BUILD:13:13: no such target '//plugins/api-provider:api-provider.api':
    target 'api-provider.api' not declared in package 'plugins/api-provider' defined by
    gerrit/plugins/api-provider/BUILD (did you mean 'api-provider.jar'? Tip: use `query
    "//plugins/api-provider:*"` to see all the targets in that package) and referenced
    by '//plugins/api-consumer:api-provider-neverlink'
```

The name used as `api-provider` and that name should be used.